### PR TITLE
:sparkles: Ajout de la homepage

### DIFF
--- a/BookMyCoach/settings.py
+++ b/BookMyCoach/settings.py
@@ -54,12 +54,13 @@ ROOT_URLCONF = 'BookMyCoach.urls'
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.templates.backends.django.DjangoTemplates',
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
         'DIRS': [],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
-                'django.templates.context_processors.request',
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
             ],

--- a/BookMyCoach/urls.py
+++ b/BookMyCoach/urls.py
@@ -15,8 +15,9 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path("", include("coaching.urls")),
 ]

--- a/coaching/templates/coaching/base.html
+++ b/coaching/templates/coaching/base.html
@@ -6,7 +6,7 @@
 </head>
 <body>
 <header>
-    <h1>Mon Site de Coaching</h1>
+    <h1>Book My Coach</h1>
     <nav>
         <a href="#">Accuil</a>
         <a href="#">Connection</a>
@@ -19,7 +19,7 @@
 </main>
 
 <footer>
-    <p>&copy; 2025 - Mon Site de Coaching - Tous droits réservés.</p>
+    <p>&copy; 2025 - Book My Coach - Tous droits réservés.</p>
     <p>Contact: BookMyCoach@outlook.fr</p>
 </footer>
 

--- a/coaching/views.py
+++ b/coaching/views.py
@@ -1,3 +1,9 @@
 from django.shortcuts import render
 
-# Create your views here.
+def home(request):
+    """
+    Afficher la page d'accueil du site de coaching.
+    :param request:
+    :return:
+    """
+    return render(request, 'coaching/accueil.html')


### PR DESCRIPTION
## Summary by Sourcery

Add a homepage view and route for the coaching app, update site branding, and correct template settings

New Features:
- Add `home` view in the coaching app to render the accueil template
- Configure the root URL to include the coaching app and serve the homepage

Bug Fixes:
- Fix the Django template backend path in settings

Enhancements:
- Add `debug` context processor to template settings
- Update base template branding from “Mon Site de Coaching” to “Book My Coach”