### PR TITLE
:sparkles: modification des sujets des rdv

### DIFF
--- a/coaching/models.py
+++ b/coaching/models.py
@@ -13,13 +13,31 @@ class Seance(models.Model):
         ('ANNULEE', 'Annulée'),
     ]
 
+    SUJET_CHOICES = [
+        ('PERTE POIDS', '🔥 Perte de poids / sèche'),
+        ('PRISE MASSE', '💪 Prise de masse / hypertrophie'),
+        ('SOUPLESSE', '🧘 Souplesse et mobilité'),
+        ('REMISE FORME', '🏃 Remise en forme / reprise du sport'),
+        ('RENFORCEMENT', '🧍‍♂️ Renforcement musculaire général'),
+        ('PREPA PHYSIQUE', '⚽ Préparation physique spécifique (sport en particulier)'),
+        ('EQUILIBRE', '♻️ Équilibre sport / récupération / sommeil'),
+        ('TRAVAIL CIBLE', '🦵 Travail ciblé (abdos, fessiers, bras, jambes…)'),
+        ('MOTIVATION', '🧠 Motivation et discipline dans l\'entraînement'),
+        ('POST BLESSURE', '👩‍⚕️ Accompagnement post-blessure / réathlétisation'),
+        ('ENDURANCE', '⏱️ Coaching pour améliorer l’endurance / cardio'),
+        ('PROGRAMME', '📅 Création de programme personnalisé'),
+        ('AUTRE', '❓ Autre (à préciser)'),
+    ]
+
     client = models.ForeignKey(User, on_delete=models.CASCADE, related_name='seances_client')
     coach = models.ForeignKey(User, on_delete=models.CASCADE, related_name='seances_coach')
     date = models.DateField()
     heure_debut = models.TimeField()
-    sujet = models.CharField(max_length=200)
+    sujet = models.CharField(max_length=100, choices=SUJET_CHOICES)
     statut = models.CharField(max_length=10, choices=STATUS_CHOICES, default='A_VENIR')
-    notes_coach = models.TextField(blank=True, null=True) # Pour la fonctionnalité bonus
+    notes_coach = models.TextField(blank=True, null=True)
+
+
 
     class Meta:
         # Assure qu'un coach ne peut pas avoir deux rendez-vous en même temps


### PR DESCRIPTION
## Summary by Sourcery

Introduce a predefined list of session topics with icons and enforce them via the `choices` attribute on the `sujet` field in the `Seance` model.

Enhancements:
- Define `SUJET_CHOICES` with emoji-annotated topics for sessions
- Update the `sujet` field to use `SUJET_CHOICES` and reduce its max length to 100

Chores:
- Remove an outdated comment from the `notes_coach` field